### PR TITLE
Fixed userid mappings on restore

### DIFF
--- a/backup/moodle2/restore_certificate_stepslib.php
+++ b/backup/moodle2/restore_certificate_stepslib.php
@@ -69,6 +69,9 @@ class restore_certificate_activity_structure_step extends restore_activity_struc
 
         $data->certificateid = $this->get_new_parentid('certificate');
         $data->timecreated = $this->apply_date_offset($data->timecreated);
+        if ($data->userid > 0) {
+            $data->userid = $this->get_mappingid('user', $data->userid);
+        }
 
         $newitemid = $DB->insert_record('certificate_issues', $data);
         $this->set_mapping('certificate_issue', $oldid, $newitemid);


### PR DESCRIPTION
Hi,

We recently restored a backed up course into another Moodle, and found that the userids in the certificate_issues table did not get updated. I copied the way that the mod/assign plugin updates these mappings and have updated the restore code to do the same. This seems to fix this issue. 

As far as I can tell the issue is present in all versions of this plugin, but was not sure how you would like them all to be updated, so have just done master at this stage.