### PR TITLE
Managers listed by default on certificates.

### DIFF
--- a/db/access.php
+++ b/db/access.php
@@ -65,8 +65,7 @@ $capabilities = array(
         'contextlevel' => CONTEXT_MODULE,
         'archetypes' => array(
             'teacher' => CAP_ALLOW,
-            'editingteacher' => CAP_ALLOW,
-            'manager' => CAP_ALLOW
+            'editingteacher' => CAP_ALLOW
         )
     ),
 


### PR DESCRIPTION
During testing we found that our managers that we assigned at the site level were being listed on certificates when "Show teachers" was enabled. This is because managers are given the capability 'mod/certificate:printteacher' by default.

Does this make sense for the most systems? Isn't the manager role used mainly for administrative and not teaching purposes?

This patch changes that default.

Also, I want to contribute another patch in which certificate_get_teachers() uses 'mod/certificate:printteacher' rather than 'mod/certificate:manage', again because of manager users being included in the emails when they are assigned at the site or category level of the course. Would that be acceptable?