### PR TITLE
Add a capability to control which users get emailed when a certificate is issued

### DIFF
--- a/db/access.php
+++ b/db/access.php
@@ -69,4 +69,15 @@ $capabilities = array(
         )
     ),
 
+    'mod/certificate:email' => array(
+
+            'captype' => 'read',
+            'contextlevel' => CONTEXT_MODULE,
+            'archetypes' => array(
+                    'teacher' => CAP_ALLOW,
+                    'editingteacher' => CAP_ALLOW,
+                    'manager' => CAP_ALLOW
+            )
+    ),
+
 );

--- a/lang/en/certificate.php
+++ b/lang/en/certificate.php
@@ -41,6 +41,7 @@ $string['borderstyle'] = 'Border Image';
 $string['borderstyle_help'] = 'The Border Image option allows you to choose a border image from the certificate/pix/borders folder.  Select the border image that you want around the certificate edges or select no border.';
 $string['certificate'] = 'Verification for certificate code:';
 $string['certificate:addinstance'] = 'Add a certificate instance';
+$string['certificate:email'] = 'Be emailed when a student receives a certificate';
 $string['certificate:manage'] = 'Manage a certificate instance';
 $string['certificate:printteacher'] = 'Be listed as a teacher on the certificate if the print teacher setting is on';
 $string['certificate:student'] = 'Retrieve a certificate';

--- a/locallib.php
+++ b/locallib.php
@@ -60,7 +60,7 @@ function certificate_get_teachers($certificate, $user, $course, $cm) {
     global $USER;
 
     $context = context_module::instance($cm->id);
-    $potteachers = get_users_by_capability($context, 'mod/certificate:manage',
+    $potteachers = get_users_by_capability($context, 'mod/certificate:email',
         '', '', '', '', '', '', false, false);
     if (empty($potteachers)) {
         return array();


### PR DESCRIPTION
Previously all users with the manage capability would get the email, now there is a separate email capability.
This is useful when there are sitewide roles that need to manage certificates at course level, but these users don't want/need to get emails everytime a certificate is generated